### PR TITLE
Show help by default instead of running demo

### DIFF
--- a/packages/atxp/src/help.ts
+++ b/packages/atxp/src/help.ts
@@ -1,0 +1,32 @@
+import chalk from 'chalk';
+
+export function showHelp(): void {
+  console.log(chalk.bold(chalk.blue('ATXP CLI')));
+  console.log(chalk.gray('Command line tool for creating ATXP projects and running demos'));
+  console.log();
+  
+  console.log(chalk.bold('Usage:'));
+  console.log('  npx atxp <command> [options]');
+  console.log();
+  
+  console.log(chalk.bold('Commands:'));
+  console.log('  ' + chalk.cyan('demo') + '     ' + 'Run the ATXP demo application');
+  console.log('  ' + chalk.cyan('create') + '   ' + 'Create a new ATXP project');
+  console.log('  ' + chalk.cyan('help') + '     ' + 'Show this help message');
+  console.log();
+  
+  console.log(chalk.bold('Demo Options:'));
+  console.log('  ' + chalk.yellow('--verbose, -v') + '  ' + 'Show detailed logs');
+  console.log('  ' + chalk.yellow('--refresh') + '      ' + 'Force refresh the demo from GitHub');
+  console.log();
+  
+  console.log(chalk.bold('Examples:'));
+  console.log('  npx atxp demo              # Run the demo');
+  console.log('  npx atxp demo --verbose    # Run demo with detailed logs');
+  console.log('  npx atxp create            # Create a new project');
+  console.log();
+  
+  console.log(chalk.bold('Learn more:'));
+  console.log('  Website: ' + chalk.underline('https://atxp.dev'));
+  console.log('  GitHub:  ' + chalk.underline('https://github.com/atxp-dev/cli'));
+}

--- a/packages/atxp/src/index.ts
+++ b/packages/atxp/src/index.ts
@@ -2,16 +2,31 @@
 
 import { createProject } from './create-project.js';
 import { runDemo } from './run-demo.js';
+import { showHelp } from './help.js';
+
+// Get the command from arguments
+const command = process.argv[2];
 
 // Detect if we're in create mode (npm create atxp or npx atxp create)
 const isCreateMode = process.env.npm_config_argv?.includes('create') || 
                      process.argv.includes('--create') || 
-                     process.argv[2] === 'create';
+                     command === 'create';
 
+// Handle different commands
 if (isCreateMode) {
   console.log('Creating new ATXP project...');
   createProject();
-} else {
+} else if (command === 'demo') {
   console.log('Starting ATXP demo...');
   runDemo();
+} else if (command === 'help' || command === '--help' || command === '-h') {
+  showHelp();
+} else if (!command) {
+  // No command provided - show help instead of running demo
+  showHelp();
+} else {
+  // Unknown command
+  console.log(`Unknown command: ${command}`);
+  console.log('Run "npx atxp help" for usage information.');
+  process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Changed default behavior of `npx atxp` from running demo to showing help
- Added comprehensive help module with usage examples and command documentation
- Require explicit `npx atxp demo` command to run the demo application

## Changes
- **New file**: `src/help.ts` - Help display module with CLI documentation
- **Updated**: `src/index.ts` - Modified command parsing to show help by default

## Test plan
- [x] `npx atxp` now shows help instead of running demo
- [x] `npx atxp help` displays help correctly  
- [x] `npx atxp demo` still runs the demo when explicitly requested
- [x] `npx atxp create` continues to work for project creation
- [x] Invalid commands show proper error messages with help suggestion

Fixes: https://linear.app/novellum/issue/ATXP-240/running-npx-atxp-should-print-out-help

🤖 Generated with [Claude Code](https://claude.ai/code)