### PR TITLE
Add configurable port and directory options for demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This monorepo contains:
 ### Demo Options
 - `--verbose, -v` - Show detailed logs
 - `--refresh` - Force refresh demo from GitHub
+- `--port, -p` - Specify port number (default: 8016)
+- `--dir, -d` - Specify demo directory (default: ~/.cache/atxp/demo)
 
 ## Examples
 
@@ -43,6 +45,15 @@ npx atxp demo
 
 # Run with detailed output  
 npx atxp demo --verbose
+
+# Use custom port
+npx atxp demo --port 3000
+
+# Use custom directory
+npx atxp demo --dir ./my-demo
+
+# Combine options
+npx atxp demo --port 3000 --dir ./my-demo --verbose
 
 # Force refresh from GitHub
 npx atxp demo --refresh

--- a/packages/atxp/README.md
+++ b/packages/atxp/README.md
@@ -36,11 +36,16 @@ Runs the interactive ATXP demo application.
 **Options:**
 - `--verbose, -v` - Show detailed logs
 - `--refresh` - Force refresh demo from GitHub
+- `--port, -p` - Specify port number (default: 8016)
+- `--dir, -d` - Specify demo directory (default: ~/.cache/atxp/demo)
 
 **Examples:**
 ```bash
 npx atxp demo
 npx atxp demo --verbose
+npx atxp demo --port 3000
+npx atxp demo --dir ./my-demo
+npx atxp demo --port 3000 --dir ./my-demo --verbose
 npx atxp demo --refresh
 ```
 

--- a/packages/atxp/src/help.ts
+++ b/packages/atxp/src/help.ts
@@ -18,12 +18,17 @@ export function showHelp(): void {
   console.log(chalk.bold('Demo Options:'));
   console.log('  ' + chalk.yellow('--verbose, -v') + '  ' + 'Show detailed logs');
   console.log('  ' + chalk.yellow('--refresh') + '      ' + 'Force refresh the demo from GitHub');
+  console.log('  ' + chalk.yellow('--port, -p') + '    ' + 'Specify port number (default: 8016)');
+  console.log('  ' + chalk.yellow('--dir, -d') + '     ' + 'Specify demo directory (default: ~/.cache/atxp/demo)');
   console.log();
   
   console.log(chalk.bold('Examples:'));
-  console.log('  npx atxp demo              # Run the demo');
-  console.log('  npx atxp demo --verbose    # Run demo with detailed logs');
-  console.log('  npx atxp create            # Create a new project');
+  console.log('  npx atxp demo                          # Run the demo with defaults');
+  console.log('  npx atxp demo --verbose                # Run demo with detailed logs');
+  console.log('  npx atxp demo --port 3000              # Run demo on port 3000');
+  console.log('  npx atxp demo --dir ./my-demo          # Use custom demo directory');
+  console.log('  npx atxp demo --port 3000 --dir ./demo # Custom port and directory');
+  console.log('  npx atxp create                        # Create a new project');
   console.log();
   
   console.log(chalk.bold('Learn more:'));


### PR DESCRIPTION
## Summary
- Added configurable port and directory options for the demo command
- Refactored argument parsing logic from `run-demo.ts` to `index.ts` for better separation of concerns
- Added comprehensive documentation and examples

## Changes
- **New option**: `--port, -p` to specify custom demo port (default: 8016)
- **New option**: `--dir, -d` to specify custom demo directory (default: ~/.cache/atxp/demo)
- **Refactored**: Moved CLI argument parsing to `index.ts`
- **Improved**: Type safety with `DemoOptions` interface
- **Updated**: Help text and README documentation

## New Usage Examples
```bash
# Use custom port
npx atxp demo --port 3000

# Use custom directory  
npx atxp demo --dir ./my-demo

# Combine options
npx atxp demo --port 9000 --dir ~/projects/demo --verbose
```

## Test plan
- [x] `npx atxp` shows updated help with new options
- [x] `npx atxp demo` works with default settings
- [x] `--port` option allows custom port specification
- [x] `--dir` option allows custom directory specification
- [x] Path resolution works for relative directories
- [x] All existing functionality preserved (verbose, refresh flags)
- [x] TypeScript compilation successful
- [x] Updated documentation reflects new options

## Benefits
- **Resolves port conflicts** - Users can avoid port 8016 if occupied
- **Flexible installation** - Users can choose demo location
- **Better architecture** - Cleaner separation of CLI vs demo logic
- **Type safety** - Structured options interface
- **Backward compatible** - All existing usage patterns work

Related to ATXP-243: Allow users to specify what port and working directory to use for the demo

🤖 Generated with [Claude Code](https://claude.ai/code)