### PR TITLE
Change demo repo to atxp-express-example

### DIFF
--- a/packages/atxp/src/create-project.ts
+++ b/packages/atxp/src/create-project.ts
@@ -18,7 +18,7 @@ interface PackageJson {
 // Template repositories
 const TEMPLATES = {
   agent: {
-    url: 'https://github.com/atxp-dev/agent-demo.git',
+    url: 'https://github.com/atxp-dev/atxp-express-example.git',
     humanText: 'Agent Demo (Full-stack web agent)'
   }
 };

--- a/packages/atxp/src/run-demo.ts
+++ b/packages/atxp/src/run-demo.ts
@@ -11,7 +11,7 @@ interface DemoOptions {
   refresh: boolean;
 }
 
-const DEMO_REPO_URL = 'https://github.com/atxp-dev/agent-demo.git';
+const DEMO_REPO_URL = 'https://github.com/atxp-dev/atxp-express-example.git';
 
 export async function runDemo(options: DemoOptions): Promise<void> {
   try {


### PR DESCRIPTION
## Summary
- Update demo repository URL from `agent-demo` to `atxp-express-example` in both run-demo.ts and create-project.ts
- The agent-demo repository has been moved/renamed to atxp-express-example

## Changes
- Updated `DEMO_REPO_URL` constant in `src/run-demo.ts`
- Updated template URL in `src/create-project.ts`

## Linear Issue
Fixes ATXP-241: https://linear.app/novellum/issue/ATXP-241/change-demo-repo-to-atxp-express-example

🤖 Generated with [Claude Code](https://claude.ai/code)