### PR TITLE
Improve CLI error handling for unrecognized commands

### DIFF
--- a/packages/atxp/src/index.ts
+++ b/packages/atxp/src/index.ts
@@ -78,9 +78,10 @@ async function main() {
     // No command provided - show help instead of running demo
     showHelp();
   } else {
-    // Unknown command
+    // Unknown command - show help instead of just error
     console.log(`Unknown command: ${command}`);
-    console.log('Run "npx atxp help" for usage information.');
+    console.log();
+    showHelp();
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
• Show full help information when user enters an unrecognized command
• Previously only displayed a brief error message requiring users to run help separately
• Improves user experience by providing immediate visibility into available commands

## Test plan
- [x] Test with invalid command (e.g., `npx atxp invalid-command`) - shows error + help
- [x] Test with valid commands (`help`, `demo`) - work as expected  
- [x] Test with no command - shows help as before
- [x] Verify build passes

🤖 Generated with [Claude Code](https://claude.ai/code)