### PR TITLE
feat(image): forward --model and --aspect-ratio; bump @atxp/client 0.10.5 → 0.11.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,14 +38,23 @@
         }
       }
     },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
     "node_modules/@atxp/client": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@atxp/client/-/client-0.10.5.tgz",
-      "integrity": "sha512-2v9Vo/czwOJuAxRv+Rx6EbDp41uDLFF1/ZCnLSwoAC38tnTLbjHEkc7t9pzilFuqEFf8DBB7ccOT9S7r3cGWSA==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@atxp/client/-/client-0.11.8.tgz",
+      "integrity": "sha512-iqamkLtSiH4G5Hpp3werKOUE/GSVyIUh7QtfoTTj7lt1l3xEV/Jc/oZ8R2F++oACGkPNeSIavrAC5/stLAswfA==",
       "license": "MIT",
       "dependencies": {
-        "@atxp/common": "0.10.5",
+        "@atxp/common": "0.11.8",
+        "@atxp/mpp": "0.11.7",
         "@modelcontextprotocol/sdk": "^1.15.0",
+        "@x402/core": "^2.9.0",
+        "@x402/evm": "^2.9.0",
         "bignumber.js": "^9.3.0",
         "oauth4webapi": "^3.8.3"
       },
@@ -55,9 +64,9 @@
       }
     },
     "node_modules/@atxp/common": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.10.5.tgz",
-      "integrity": "sha512-LYdrueEHSWs+weFk9/Ne+Ok82ZrZQgnpDxwft/VNrFxJ8yPS8Hc6K2DnOuhrYaWMSkLHuNdxqoFU3fWDYwH47g==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.11.8.tgz",
+      "integrity": "sha512-Ia8Vo6TV4ct4A1E3rFUbsmSCopIJJrBKZmUsxVMFx4IvnQhvx+8tqH50/F3rh0fgJy+ImOC93WK6a+XGraMU1Q==",
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.3.0",
@@ -66,6 +75,12 @@
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
       }
+    },
+    "node_modules/@atxp/mpp": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
+      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -3916,6 +3931,45 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4661,6 +4715,42 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -5245,6 +5335,44 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@x402/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-n9Exnt1HN4LFaINaPYhk6Cy3ICBt0e46XN1Uo5i6efIZfIoqP6pY8ONSX/M9bU4F1fpvMj0JZ3xdcBZCiGInfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@x402/evm": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.10.0.tgz",
+      "integrity": "sha512-iEGIgW5K3qM3d2S1wuBSGJ1Kfdctd+0LAN8l+33dbYZgdkvCvTDwBPjbojVJ9mXI0Zk2bt4hUpcoOgsdmr79BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.10.0",
+        "viem": "^2.39.3",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/evm/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -5305,6 +5433,27 @@
         "@zvec/bindings-darwin-arm64": "^0.2.0",
         "@zvec/bindings-linux-arm64": "^0.2.0",
         "@zvec/bindings-linux-x64": "^0.2.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/abort-controller": {
@@ -7229,6 +7378,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -8781,6 +8936,21 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -10159,9 +10329,9 @@
       "peer": true
     },
     "node_modules/oauth4webapi": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
-      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -10375,6 +10545,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.20",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
+      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {
@@ -12715,7 +12915,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12916,6 +13116,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
+      "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.20",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {
@@ -13901,7 +14152,7 @@
       "version": "1.29.0",
       "license": "MIT",
       "dependencies": {
-        "@atxp/client": "^0.10.5",
+        "@atxp/client": "^0.11.7",
         "chalk": "^5.3.0",
         "fs-extra": "^11.2.0",
         "ignore": "^7.0.5",
@@ -13963,26 +14214,6 @@
         "eslint": "^9.32.0",
         "globals": "^16.3.0",
         "vitest": "^1.0.0"
-      }
-    },
-    "packages/create-atxp/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/create-atxp/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14152,7 +14152,7 @@
       "version": "1.29.0",
       "license": "MIT",
       "dependencies": {
-        "@atxp/client": "^0.11.7",
+        "@atxp/client": "^0.11.8",
         "chalk": "^5.3.0",
         "fs-extra": "^11.2.0",
         "ignore": "^7.0.5",

--- a/packages/atxp/package.json
+++ b/packages/atxp/package.json
@@ -35,7 +35,7 @@
     "create"
   ],
   "dependencies": {
-    "@atxp/client": "^0.10.5",
+    "@atxp/client": "^0.11.7",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
     "ignore": "^7.0.5",

--- a/packages/atxp/package.json
+++ b/packages/atxp/package.json
@@ -35,7 +35,7 @@
     "create"
   ],
   "dependencies": {
-    "@atxp/client": "^0.11.7",
+    "@atxp/client": "^0.11.8",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
     "ignore": "^7.0.5",

--- a/packages/atxp/src/commands/image.ts
+++ b/packages/atxp/src/commands/image.ts
@@ -5,19 +5,35 @@ import ora from 'ora';
 const SERVER = 'image.mcp.atxp.ai';
 const POLL_INTERVAL_MS = 3000;
 
-export async function imageCommand(prompt: string): Promise<void> {
+export interface ImageOptions {
+  /** Optional model override (e.g. gpt-image-2, gpt-4o, dall-e-3, gemini-3-pro-image-preview).
+   *  When omitted, the server picks based on its default. */
+  model?: string;
+  /** Optional aspect ratio (e.g. "1:1", "16:9", "9:16"). */
+  aspectRatio?: string;
+}
+
+export async function imageCommand(prompt: string, options: ImageOptions = {}): Promise<void> {
   if (!prompt || prompt.trim().length === 0) {
     console.error(chalk.red('Error: Image prompt is required'));
-    console.log(`Usage: ${chalk.cyan('npx atxp image <prompt>')}`);
+    console.log(
+      `Usage: ${chalk.cyan('npx atxp image <prompt> [--model <model>] [--aspect-ratio <ratio>]')}`
+    );
     process.exit(1);
   }
 
   const client = await getClient(SERVER);
 
+  // Build arguments — only include optional fields when set so we never
+  // override server defaults with empty strings.
+  const args: Record<string, string> = { prompt: prompt.trim() };
+  if (options.model) args.model = options.model;
+  if (options.aspectRatio) args.aspectRatio = options.aspectRatio;
+
   // Initiate async generation
   const initResult = (await client.callTool({
     name: 'image_create_image_async',
-    arguments: { prompt: prompt.trim() },
+    arguments: args,
   })) as ToolResult;
 
   const initText = extractResult(initResult);

--- a/packages/atxp/src/help.ts
+++ b/packages/atxp/src/help.ts
@@ -19,7 +19,7 @@ export function showHelp(): void {
 
   console.log(chalk.bold('Tools:'));
   console.log('  ' + chalk.cyan('search') + ' ' + chalk.yellow('<query>') + '    ' + 'Search the web');
-  console.log('  ' + chalk.cyan('image') + ' ' + chalk.yellow('<prompt>') + '    ' + 'Generate an image');
+  console.log('  ' + chalk.cyan('image') + ' ' + chalk.yellow('<prompt>') + '    ' + 'Generate an image [--model <model>] [--aspect-ratio <ratio>]');
   console.log('  ' + chalk.cyan('music') + ' ' + chalk.yellow('<prompt>') + '    ' + 'Generate music [--lyrics <lyrics>]');
   console.log('  ' + chalk.cyan('video') + ' ' + chalk.yellow('<prompt>') + '    ' + 'Generate a video');
   console.log('  ' + chalk.cyan('x') + ' ' + chalk.yellow('<query>') + '        ' + 'Search X/Twitter');
@@ -82,6 +82,7 @@ export function showHelp(): void {
   console.log('  npx atxp login --token $TOKEN          # Log in with token (headless)');
   console.log('  npx atxp search "latest AI news"       # Search the web');
   console.log('  npx atxp image "sunset over mountains" # Generate an image');
+  console.log('  npx atxp image "wizard typing" --model gpt-image-2 --aspect-ratio 16:9');
   console.log('  npx atxp music "relaxing piano"        # Generate music');
   console.log('  npx atxp music "pop song" --lyrics "Hello world"  # Generate music with lyrics');
   console.log('  npx atxp video "ocean waves"           # Generate a video');

--- a/packages/atxp/src/index.ts
+++ b/packages/atxp/src/index.ts
@@ -8,7 +8,7 @@ import { showHelp } from './help.js';
 import { checkAllDependencies, showDependencyError } from './check-dependencies.js';
 import { login } from './login.js';
 import { searchCommand, type SearchOptions } from './commands/search.js';
-import { imageCommand } from './commands/image.js';
+import { imageCommand, type ImageOptions } from './commands/image.js';
 import { musicCommand, type MusicOptions } from './commands/music.js';
 import { videoCommand } from './commands/video.js';
 import { xCommand } from './commands/x.js';
@@ -117,6 +117,7 @@ function parseArgs(): {
   paasArgs: string[];
   toolArgs: string;
   musicOptions: MusicOptions;
+  imageOptions: ImageOptions;
   searchOptions: SearchOptions;
   memoryOptions: MemoryOptions;
   gitOptions: GitOptions;
@@ -139,6 +140,7 @@ function parseArgs(): {
       paasArgs: [],
       toolArgs: '',
       musicOptions: {},
+      imageOptions: {},
       searchOptions: {},
       memoryOptions: {},
       gitOptions: {},
@@ -298,6 +300,14 @@ function parseArgs(): {
     lyrics: getArgValue('--lyrics', ''),
   };
 
+  // Parse image options. Accept both --aspect-ratio and --aspectRatio for
+  // ergonomic parity with the underlying tool's parameter name.
+  const imageOptions: ImageOptions = {
+    model: getArgValue('--model', '') || undefined,
+    aspectRatio:
+      getArgValue('--aspect-ratio', '') || getArgValue('--aspectRatio', '') || undefined,
+  };
+
   // Parse search options
   const searchOptions: SearchOptions = {
     startDate: getArgValue('--start-date', ''),
@@ -340,6 +350,7 @@ function parseArgs(): {
     paasArgs,
     toolArgs,
     musicOptions,
+    imageOptions,
     searchOptions,
     memoryOptions,
     gitOptions,
@@ -347,7 +358,7 @@ function parseArgs(): {
   };
 }
 
-const { command, subCommand, demoOptions, createOptions, loginOptions, emailOptions, phoneOptions, paasOptions, paasArgs, toolArgs, musicOptions, searchOptions, memoryOptions, gitOptions, contactsOptions } = parseArgs();
+const { command, subCommand, demoOptions, createOptions, loginOptions, emailOptions, phoneOptions, paasOptions, paasArgs, toolArgs, musicOptions, imageOptions, searchOptions, memoryOptions, gitOptions, contactsOptions } = parseArgs();
 
 // Extract positional args from argv, skipping flag values (e.g., --path <val> --topk <val>)
 function extractPositionalArgs(startIndex: number): string {
@@ -418,7 +429,7 @@ async function main() {
       break;
 
     case 'image':
-      await imageCommand(toolArgs);
+      await imageCommand(toolArgs, imageOptions);
       break;
 
     case 'music':


### PR DESCRIPTION
## Summary

The `atxp image` command was silently dropping any model or aspect-ratio the user might want — `imageCommand(prompt)` only forwarded the prompt itself to `image_create_image_async`. For direct MCP callers (i.e. anyone *not* going through the atxp-pics wrapper, which pins `IMAGE_MODEL=gpt-image-2`), this means the server default decides, which during last week's incident silently routed to `gpt-4o-mini` via the Responses API and produced unfaithful outputs. Surfacing these flags lets CLI/agent users pin the model and aspect ratio explicitly.

This PR also bumps `@atxp/client` from `^0.10.5` to `^0.11.7` to align with what the MCP servers (image, music, videogen) are running. The 0.10.x series predates the middleware-settlement work and several payment-protocol fixes in 0.11.x; the API surface used here (`atxpClient`, `ATXPAccount`) is unchanged.

### Code shape

```ts
// commands/image.ts
export interface ImageOptions {
  model?: string;
  aspectRatio?: string;
}

export async function imageCommand(prompt: string, options: ImageOptions = {}) {
  // ...
  const args: Record<string, string> = { prompt: prompt.trim() };
  if (options.model) args.model = options.model;
  if (options.aspectRatio) args.aspectRatio = options.aspectRatio;
  await client.callTool({ name: 'image_create_image_async', arguments: args });
}
```

`index.ts` parses `--model` and `--aspect-ratio` (also accepts `--aspectRatio` for parity with the underlying tool parameter name). Empty/unset options are not added to `args`, so server defaults still apply when nothing is specified.

## Local test plan

```bash
# clone branch
gh pr checkout <this-pr-number>
cd packages/atxp
npm install
npm run build

# verify build
npm run typecheck      # tsc --noEmit, clean
npm test               # 302 tests passing

# smoke against prod (or a local image MCP server) — requires you to be logged in already
node dist/index.js image "wizard typing at a computer" --model gpt-image-2 --aspect-ratio 16:9
node dist/index.js image "test"                                    # no flags — server default
node dist/index.js image "test" --model gpt-image-2                # only model
node dist/index.js image "test" --aspect-ratio 1:1                 # only aspect ratio
```

Verify in each case the tool args going to `image_create_image_async` reflect what was passed (or omit the field cleanly when not supplied). The image MCP server logs `Inferred creator '...' from model '...'` when a model is forwarded — easy way to confirm from the server side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)